### PR TITLE
Added user-agent header and COURIER_AUTH_TOKEN env var support.

### DIFF
--- a/lib/trycourier.rb
+++ b/lib/trycourier.rb
@@ -18,8 +18,8 @@ module Courier
   end
 
   class Client
-    def initialize(api_key)
-      @api_key = api_key
+    def initialize(api_key = nil)
+      @api_key = api_key || ENV['COURIER_AUTH_TOKEN']
       @uri = URI.parse('https://api.trycourier.app/send')
     end
 
@@ -43,6 +43,7 @@ module Courier
       req = Net::HTTP::Post.new(@uri)
       req["authorization"] = "Bearer #{@api_key}"
       req["content-type"] = "application/json"
+      req["User-Agent"] = "courier-ruby/#{Courier::VERSION}"
       req.body = body.to_json
 
       res = http.request(req)


### PR DESCRIPTION
## Description of the change

> * Added `courier-ruby/#{VERSION}` as the User-Agent header. 
> * Added the ability to set the Courier Auth Token using the `COURIER_AUTH_TOKEN` environment variable.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 