### PR TITLE
Fix SSL verification

### DIFF
--- a/lib/trycourier.rb
+++ b/lib/trycourier.rb
@@ -41,7 +41,7 @@ module Courier
 
       http = Net::HTTP.new(@uri.host, @uri.port)
       http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
       req = Net::HTTP::Post.new(@uri)
       req["authorization"] = "Bearer #{@auth_token}"


### PR DESCRIPTION
The current implementation of this library disables SSL verification, by
setting `verify_mode` to `OpenSSL::SSL::VERIFY_NONE` on the instantiated
`Net::HTTP` client.

This poses a potentially huge security risk for end-users, as it means
that the SSL certificate of Courier's servers is not confirmed to be
valid prior to sending the request. Subsequently, a malicious actor
could run a man-in-the-middle attack against folks using Courier and
intercept their requests, collecting potentially sensitive user data
in the process.

This updates the `verify_mode` to be `OpenSSL::SSL::VERIFY_PEER`, which
correctly ensures that the SSL certificate of the server being connected
to is valid.

FWIW, it's significantly easier to mitigate these risks by using a higher-level
HTTP library than `Net::HTTP` – [HTTParty](https://github.com/jnunemaker/httparty), [Faraday](https://github.com/lostisland/faraday) and [HTTP](https://github.com/httprb/http) are all worth 
considering.

Further reading: https://brakemanscanner.org/docs/warning_types/ssl_verification_bypass/