### PR TITLE
docs: sync README from api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
 # Courier Ruby SDK
 
-The Courier Ruby SDK provides typed access to the Courier REST API from any Ruby 3.2+ application. It ships with Yard docstrings, RBS and RBI type definitions for Sorbet, and uses `net/http` with connection pooling.
+The Courier Ruby SDK provides typed access to the Courier REST API from Ruby applications. Use it to send notifications, manage user profiles, check message status, issue JWT tokens for client-side SDKs, and more.
 
 ## Installation
 
-Add to your `Gemfile`:
+Add the gem to your `Gemfile`:
+
+<!-- x-release-please-start-version -->
 
 ```ruby
-gem "trycourier"
+gem "trycourier", "~> 4.26.0"
 ```
 
-Then run `bundle install`.
+<!-- x-release-please-end -->
+
+Then run `bundle install`. Requires Ruby 3.2+.
 
 ## Quick Start
 
@@ -19,24 +22,20 @@ Then run `bundle install`.
 require "bundler/setup"
 require "courier"
 
-client = Courier::Client.new
-
-response = client.send_.message(
-  message: {
-    to: { email: "you@example.com" },
-    content: {
-      title: "Hello from Courier!",
-      body: "Your first notification, sent with the Ruby SDK."
-    }
-  }
+courier = Courier::Client.new(
+  api_key: ENV["COURIER_API_KEY"] # the default, can be omitted
 )
 
-puts response.request_id
+response = courier.send_.message(
+  message: {to: {user_id: "your_user_id"}, template: "your_template_id", data: {foo: "bar"}}
+)
+
+puts(response.requestId)
 ```
 
-The client reads `COURIER_API_KEY` from your environment automatically. You can also pass it explicitly: `Courier::Client.new(api_key: "your-key")`.
+The client reads `COURIER_API_KEY` from your environment automatically.
 
-> **Note**: The method is `send_` (with trailing underscore) because `send` is a reserved method in Ruby.
+Note the trailing underscore on `send_` — `send` is reserved in Ruby.
 
 ## Documentation
 
@@ -45,5 +44,3 @@ Full documentation: **[courier.com/docs/sdk-libraries/ruby](https://www.courier.
 - [Quickstart](https://www.courier.com/docs/getting-started/quickstart/)
 - [Send API](https://www.courier.com/docs/platform/sending/send-message/)
 - [API Reference](https://www.courier.com/docs/reference/get-started/)
-- [RubyDoc](https://gemdocs.org/gems/trycourier)
-<!-- AUTO-GENERATED-OVERVIEW:END -->


### PR DESCRIPTION
Takes ownership of this README in the SDK repo.

`trycourier/api-spec` used to overwrite it on every spec merge, from its own `READMEs/<target>.md` overlay. That overlay is being removed (trycourier/api-spec#200) — kits are now generated SDK source only, and `README.md` is pruned from them. This lands the api-spec copy here once so nothing is lost, and from now on **this repo owns its README**.

Two notes:

- The `AUTO-GENERATED-OVERVIEW` markers are dropped. They claimed the file was synced from mintlify-docs, but `mintlify-docs/sdk-libraries/readme-exports/readme-sync-map.json` targets only the web and mobile SDKs — never this repo. Nothing has been rewriting them, and the banner told maintainers not to edit a file they in fact own.
- Where the install snippet carries a version, it is wrapped in `x-release-please-start-version` markers so release-please keeps it current on each release (this repo already lists `README.md` in its `extra-files`).

Review the content as a normal docs change — if the previous version read better in places, keep those parts.