### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/test/courier/resources/automations/invoke_test.rb
+++ b/test/courier/resources/automations/invoke_test.rb
@@ -23,7 +23,7 @@ class Courier::Test::Resources::Automations::InvokeTest < Courier::Test::Resourc
   def test_invoke_by_template_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.automations.invoke.invoke_by_template("templateId", recipient: "recipient")
+    response = @courier.automations.invoke.invoke_by_template("templateId", recipient: "user_abc")
 
     assert_pattern do
       response => Courier::AutomationInvokeResponse

--- a/test/courier/resources/brands_test.rb
+++ b/test/courier/resources/brands_test.rb
@@ -52,7 +52,7 @@ class Courier::Test::Resources::BrandsTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.brands.update("brand_id", name: "name")
+    response = @courier.brands.update("brand_id", name: "My Brand")
 
     assert_pattern do
       response => Courier::Brand

--- a/test/courier/resources/bulk_test.rb
+++ b/test/courier/resources/bulk_test.rb
@@ -16,7 +16,7 @@ class Courier::Test::Resources::BulkTest < Courier::Test::ResourceTest
   def test_create_job_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.bulk.create_job(message: {event: "event"})
+    response = @courier.bulk.create_job(message: {event: "welcome-series"})
 
     assert_pattern do
       response => Courier::Models::BulkCreateJobResponse

--- a/test/courier/resources/lists/subscriptions_test.rb
+++ b/test/courier/resources/lists/subscriptions_test.rb
@@ -23,7 +23,11 @@ class Courier::Test::Resources::Lists::SubscriptionsTest < Courier::Test::Resour
   def test_add_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.lists.subscriptions.add("list_id", recipients: [{recipientId: "recipientId"}])
+    response =
+      @courier.lists.subscriptions.add(
+        "list_id",
+        recipients: [{recipientId: "user_abc"}, {recipientId: "user_def"}]
+      )
 
     assert_pattern do
       response => nil
@@ -33,7 +37,11 @@ class Courier::Test::Resources::Lists::SubscriptionsTest < Courier::Test::Resour
   def test_subscribe_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.lists.subscriptions.subscribe("list_id", recipients: [{recipientId: "recipientId"}])
+    response =
+      @courier.lists.subscriptions.subscribe(
+        "list_id",
+        recipients: [{recipientId: "user_abc"}, {recipientId: "user_def"}]
+      )
 
     assert_pattern do
       response => nil

--- a/test/courier/resources/lists_test.rb
+++ b/test/courier/resources/lists_test.rb
@@ -25,7 +25,7 @@ class Courier::Test::Resources::ListsTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.lists.update("list_id", name: "name")
+    response = @courier.lists.update("list_id", name: "Product Updates")
 
     assert_pattern do
       response => nil

--- a/test/courier/resources/notifications/checks_test.rb
+++ b/test/courier/resources/notifications/checks_test.rb
@@ -10,7 +10,7 @@ class Courier::Test::Resources::Notifications::ChecksTest < Courier::Test::Resou
       @courier.notifications.checks.update(
         "submissionId",
         id: "id",
-        checks: [{id: "id", status: :RESOLVED, type: :custom}]
+        checks: [{id: "abc-123", status: :RESOLVED, type: :custom}]
       )
 
     assert_pattern do

--- a/test/courier/resources/profiles/lists_test.rb
+++ b/test/courier/resources/profiles/lists_test.rb
@@ -39,7 +39,7 @@ class Courier::Test::Resources::Profiles::ListsTest < Courier::Test::ResourceTes
   def test_subscribe_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.profiles.lists.subscribe("user_id", lists: [{listId: "listId"}])
+    response = @courier.profiles.lists.subscribe("user_id", lists: [{listId: "example.list.id"}])
 
     assert_pattern do
       response => Courier::Models::Profiles::ListSubscribeResponse

--- a/test/courier/resources/profiles_test.rb
+++ b/test/courier/resources/profiles_test.rb
@@ -6,7 +6,7 @@ class Courier::Test::Resources::ProfilesTest < Courier::Test::ResourceTest
   def test_create_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.profiles.create("user_id", profile: {foo: "bar"})
+    response = @courier.profiles.create("user_id", profile: {email: "bar", phone_number: "bar"})
 
     assert_pattern do
       response => Courier::Models::ProfileCreateResponse
@@ -39,7 +39,8 @@ class Courier::Test::Resources::ProfilesTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.profiles.update("user_id", patch: [{op: "op", path: "path", value: "value"}])
+    response =
+      @courier.profiles.update("user_id", patch: [{op: "replace", path: "/email", value: "jdoe@example.com"}])
 
     assert_pattern do
       response => nil
@@ -59,7 +60,8 @@ class Courier::Test::Resources::ProfilesTest < Courier::Test::ResourceTest
   def test_replace_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.profiles.replace("user_id", profile: {foo: "bar"})
+    response =
+      @courier.profiles.replace("user_id", profile: {email: "bar", phone_number: "bar", locale: "bar"})
 
     assert_pattern do
       response => Courier::Models::ProfileReplaceResponse

--- a/test/courier/resources/providers_test.rb
+++ b/test/courier/resources/providers_test.rb
@@ -6,7 +6,7 @@ class Courier::Test::Resources::ProvidersTest < Courier::Test::ResourceTest
   def test_create_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.providers.create(provider: "provider")
+    response = @courier.providers.create(provider: "sendgrid")
 
     assert_pattern do
       response => Courier::Provider
@@ -50,7 +50,7 @@ class Courier::Test::Resources::ProvidersTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.providers.update("id", provider: "provider")
+    response = @courier.providers.update("id", provider: "sendgrid")
 
     assert_pattern do
       response => Courier::Provider

--- a/test/courier/resources/tenants/templates_test.rb
+++ b/test/courier/resources/tenants/templates_test.rb
@@ -79,7 +79,7 @@ class Courier::Test::Resources::Tenants::TemplatesTest < Courier::Test::Resource
       @courier.tenants.templates.replace(
         "template_id",
         tenant_id: "tenant_id",
-        template: {content: {elements: [{}], version: "version"}}
+        template: {content: {elements: [{}], version: "2022-01-01"}}
       )
 
     assert_pattern do

--- a/test/courier/resources/tenants_test.rb
+++ b/test/courier/resources/tenants_test.rb
@@ -28,7 +28,7 @@ class Courier::Test::Resources::TenantsTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.tenants.update("tenant_id", name: "name")
+    response = @courier.tenants.update("tenant_id", name: "Acme Corp")
 
     assert_pattern do
       response => Courier::Tenant

--- a/test/courier/resources/translations_test.rb
+++ b/test/courier/resources/translations_test.rb
@@ -16,7 +16,8 @@ class Courier::Test::Resources::TranslationsTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.translations.update("locale", domain: "domain", body: "body")
+    response =
+      @courier.translations.update("locale", domain: "domain", body: "msgid \"Hello\"\nmsgstr \"Hola\"")
 
     assert_pattern do
       response => nil

--- a/test/courier/resources/users/tenants_test.rb
+++ b/test/courier/resources/users/tenants_test.rb
@@ -27,7 +27,11 @@ class Courier::Test::Resources::Users::TenantsTest < Courier::Test::ResourceTest
   def test_add_multiple_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.users.tenants.add_multiple("user_id", tenants: [{tenant_id: "tenant_id"}])
+    response =
+      @courier.users.tenants.add_multiple(
+        "user_id",
+        tenants: [{tenant_id: "tenant_abc"}, {tenant_id: "tenant_def"}]
+      )
 
     assert_pattern do
       response => nil

--- a/test/courier/resources/users/tokens_test.rb
+++ b/test/courier/resources/users/tokens_test.rb
@@ -16,7 +16,12 @@ class Courier::Test::Resources::Users::TokensTest < Courier::Test::ResourceTest
   def test_update_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.users.tokens.update("token", user_id: "user_id", patch: [{op: "op", path: "path"}])
+    response =
+      @courier.users.tokens.update(
+        "token",
+        user_id: "user_id",
+        patch: [{op: "replace", path: "/expiry_date"}]
+      )
 
     assert_pattern do
       response => nil

--- a/test/courier/resources/workspace_preferences/topics_test.rb
+++ b/test/courier/resources/workspace_preferences/topics_test.rb
@@ -95,8 +95,8 @@ class Courier::Test::Resources::WorkspacePreferences::TopicsTest < Courier::Test
       @courier.workspace_preferences.topics.replace(
         "topic_id",
         section_id: "section_id",
-        default_status: :OPTED_OUT,
-        name: "name"
+        default_status: :OPTED_IN,
+        name: "Product Updates"
       )
 
     assert_pattern do

--- a/test/courier/resources/workspace_preferences_test.rb
+++ b/test/courier/resources/workspace_preferences_test.rb
@@ -102,7 +102,7 @@ class Courier::Test::Resources::WorkspacePreferencesTest < Courier::Test::Resour
   def test_replace_required_params
     skip("Mock server tests are disabled")
 
-    response = @courier.workspace_preferences.replace("section_id", name: "name")
+    response = @courier.workspace_preferences.replace("section_id", name: "Account Notifications")
 
     assert_pattern do
       response => Courier::WorkspacePreferenceGetResponse


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

16 files changed, 41 insertions(+), 21 deletions(-)

<details><summary>Files</summary>

```
 test/courier/resources/automations/invoke_test.rb           |  2 +-
 test/courier/resources/brands_test.rb                       |  2 +-
 test/courier/resources/bulk_test.rb                         |  2 +-
 test/courier/resources/lists/subscriptions_test.rb          | 12 ++++++++++--
 test/courier/resources/lists_test.rb                        |  2 +-
 test/courier/resources/notifications/checks_test.rb         |  2 +-
 test/courier/resources/profiles/lists_test.rb               |  2 +-
 test/courier/resources/profiles_test.rb                     |  8 +++++---
 test/courier/resources/providers_test.rb                    |  4 ++--
 test/courier/resources/tenants/templates_test.rb            |  2 +-
 test/courier/resources/tenants_test.rb                      |  2 +-
 test/courier/resources/translations_test.rb                 |  3 ++-
 test/courier/resources/users/tenants_test.rb                |  6 +++++-
 test/courier/resources/users/tokens_test.rb                 |  7 ++++++-
 test/courier/resources/workspace_preferences/topics_test.rb |  4 ++--
 test/courier/resources/workspace_preferences_test.rb        |  2 +-
 16 files changed, 41 insertions(+), 21 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
