### PR TITLE
docs(api): describe every broadcast id path parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    trycourier (4.26.0)
+    trycourier (4.26.1)
       cgi
       connection_pool
 

--- a/lib/courier/resources/broadcasts.rb
+++ b/lib/courier/resources/broadcasts.rb
@@ -35,7 +35,8 @@ module Courier
       #
       # @overload retrieve(broadcast_id, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to retrieve, identified by the `id` returned when it was created.
+      #
       # @param request_options [Courier::RequestOptions, Hash{Symbol=>Object}, nil]
       #
       # @return [Courier::Models::Broadcast]
@@ -55,7 +56,7 @@ module Courier
       #
       # @overload update(broadcast_id, name:, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to rename.
       #
       # @param name [String] New human-readable name.
       #
@@ -106,7 +107,8 @@ module Courier
       #
       # @overload archive(broadcast_id, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to archive.
+      #
       # @param request_options [Courier::RequestOptions, Hash{Symbol=>Object}, nil]
       #
       # @return [Courier::Models::Broadcast]
@@ -126,7 +128,8 @@ module Courier
       #
       # @overload cancel(broadcast_id, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to cancel.
+      #
       # @param request_options [Courier::RequestOptions, Hash{Symbol=>Object}, nil]
       #
       # @return [Courier::Models::Broadcast]
@@ -141,12 +144,16 @@ module Courier
         )
       end
 
+      # Some parameter documentations has been truncated, see
+      # {Courier::Models::BroadcastDuplicateParams} for more details.
+      #
       # Duplicate a broadcast (and its template) into a new draft named "{source name}
       # (copy)".
       #
       # @overload duplicate(broadcast_id, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to copy. The duplicate is created as a new draft and this broadcas
+      #
       # @param request_options [Courier::RequestOptions, Hash{Symbol=>Object}, nil]
       #
       # @return [Courier::Models::Broadcast]
@@ -167,7 +174,7 @@ module Courier
       #
       # @overload put_content(broadcast_id, content:, state: nil, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast whose content you want to replace.
       #
       # @param content [Courier::Models::NotificationContentPutRequest::Content] Elemental content payload. The server defaults `version` when omitted.
       #
@@ -198,7 +205,7 @@ module Courier
       #
       # @overload retrieve_content(broadcast_id, version: nil, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast whose content you want to read.
       #
       # @param version [String] Accepts `draft`, `published`, or a version string (e.g. `v001`). Defaults to `dr
       #
@@ -228,7 +235,7 @@ module Courier
       #
       # @overload schedule(broadcast_id, recipient_id:, recipient_type:, scheduled_to:, timezone: nil, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to schedule.
       #
       # @param recipient_id [String] ID of the target list or audience.
       #
@@ -259,7 +266,7 @@ module Courier
       #
       # @overload send_(broadcast_id, recipient_id:, recipient_type:, request_options: {})
       #
-      # @param broadcast_id [String]
+      # @param broadcast_id [String] The broadcast to send.
       #
       # @param recipient_id [String] ID of the target list or audience.
       #

--- a/rbi/courier/resources/broadcasts.rbi
+++ b/rbi/courier/resources/broadcasts.rbi
@@ -31,7 +31,11 @@ module Courier
           request_options: Courier::RequestOptions::OrHash
         ).returns(Courier::Broadcast)
       end
-      def retrieve(broadcast_id, request_options: {})
+      def retrieve(
+        # The broadcast to retrieve, identified by the `id` returned when it was created.
+        broadcast_id,
+        request_options: {}
+      )
       end
 
       # Update a broadcast's name. Content is edited via the broadcast's notification
@@ -44,6 +48,7 @@ module Courier
         ).returns(Courier::Broadcast)
       end
       def update(
+        # The broadcast to rename.
         broadcast_id,
         # New human-readable name.
         name:,
@@ -77,7 +82,11 @@ module Courier
           request_options: Courier::RequestOptions::OrHash
         ).returns(Courier::Broadcast)
       end
-      def archive(broadcast_id, request_options: {})
+      def archive(
+        # The broadcast to archive.
+        broadcast_id,
+        request_options: {}
+      )
       end
 
       # Cancel a broadcast's pending schedule, returning it to the draft state. Only
@@ -88,7 +97,11 @@ module Courier
           request_options: Courier::RequestOptions::OrHash
         ).returns(Courier::Broadcast)
       end
-      def cancel(broadcast_id, request_options: {})
+      def cancel(
+        # The broadcast to cancel.
+        broadcast_id,
+        request_options: {}
+      )
       end
 
       # Duplicate a broadcast (and its template) into a new draft named "{source name}
@@ -99,7 +112,12 @@ module Courier
           request_options: Courier::RequestOptions::OrHash
         ).returns(Courier::Broadcast)
       end
-      def duplicate(broadcast_id, request_options: {})
+      def duplicate(
+        # The broadcast to copy. The duplicate is created as a new draft and this
+        # broadcast is left unchanged.
+        broadcast_id,
+        request_options: {}
+      )
       end
 
       # Author the broadcast's content by replacing the draft elemental content of its
@@ -114,6 +132,7 @@ module Courier
         ).returns(Courier::NotificationContentMutationResponse)
       end
       def put_content(
+        # The broadcast whose content you want to replace.
         broadcast_id,
         # Elemental content payload. The server defaults `version` when omitted.
         content:,
@@ -134,6 +153,7 @@ module Courier
         ).returns(Courier::NotificationContentGetResponse)
       end
       def retrieve_content(
+        # The broadcast whose content you want to read.
         broadcast_id,
         # Accepts `draft`, `published`, or a version string (e.g. `v001`). Defaults to
         # `draft`.
@@ -157,6 +177,7 @@ module Courier
         ).returns(Courier::Broadcast)
       end
       def schedule(
+        # The broadcast to schedule.
         broadcast_id,
         # ID of the target list or audience.
         recipient_id:,
@@ -183,6 +204,7 @@ module Courier
         ).returns(Courier::Broadcast)
       end
       def send_(
+        # The broadcast to send.
         broadcast_id,
         # ID of the target list or audience.
         recipient_id:,


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 43 insertions(+), 14 deletions(-)

<details><summary>Files</summary>

```
 Gemfile.lock                         |  2 +-
 lib/courier/resources/broadcasts.rb  | 25 ++++++++++++++++---------
 rbi/courier/resources/broadcasts.rbi | 30 ++++++++++++++++++++++++++----
 3 files changed, 43 insertions(+), 14 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
