### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/lib/courier/resources/bulk.rb
+++ b/lib/courier/resources/bulk.rb
@@ -65,7 +65,8 @@ module Courier
       # Some parameter documentations has been truncated, see
       # {Courier::Models::BulkListUsersParams} for more details.
       #
-      # Get Bulk Job Users
+      # Returns the users ingested into a bulk job with paging, each carrying the status
+      # Courier recorded for it and the id of the message it produced.
       #
       # @overload list_users(job_id, cursor: nil, request_options: {})
       #
@@ -90,7 +91,9 @@ module Courier
         )
       end
 
-      # Get a bulk job
+      # Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+      # COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+      # and failures. Poll it to follow a job through to completion.
       #
       # @overload retrieve_job(job_id, request_options: {})
       #
@@ -110,7 +113,9 @@ module Courier
         )
       end
 
-      # Run a bulk job
+      # Starts processing a bulk job, sending to every user ingested into it. Returns
+      # 204 immediately; the job runs asynchronously, so poll the job to watch its
+      # status and counts.
       #
       # @overload run_job(job_id, request_options: {})
       #

--- a/rbi/courier/resources/bulk.rbi
+++ b/rbi/courier/resources/bulk.rbi
@@ -47,7 +47,8 @@ module Courier
       )
       end
 
-      # Get Bulk Job Users
+      # Returns the users ingested into a bulk job with paging, each carrying the status
+      # Courier recorded for it and the id of the message it produced.
       sig do
         params(
           job_id: String,
@@ -65,7 +66,9 @@ module Courier
       )
       end
 
-      # Get a bulk job
+      # Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+      # COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+      # and failures. Poll it to follow a job through to completion.
       sig do
         params(
           job_id: String,
@@ -79,7 +82,9 @@ module Courier
       )
       end
 
-      # Run a bulk job
+      # Starts processing a bulk job, sending to every user ingested into it. Returns
+      # 204 immediately; the job runs asynchronously, so poll the job to watch its
+      # status and counts.
       sig do
         params(
           job_id: String,


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

2 files changed, 16 insertions(+), 6 deletions(-)

<details><summary>Files</summary>

```
 lib/courier/resources/bulk.rb  | 11 ++++++++---
 rbi/courier/resources/bulk.rbi | 11 ++++++++---
 2 files changed, 16 insertions(+), 6 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
