### PR TITLE
feat(api): document section_id and section_name on a user's topic preference

### DIFF
--- a/lib/courier/models/users/topic_preference.rb
+++ b/lib/courier/models/users/topic_preference.rb
@@ -48,7 +48,23 @@ module Courier
         #   @return [Boolean, nil]
         optional :has_custom_routing, Courier::Internal::Type::Boolean, nil?: true
 
-        # @!method initialize(default_status:, status:, topic_id:, topic_name:, custom_routing: nil, has_custom_routing: nil)
+        # @!attribute section_id
+        #   The unique identifier of the section this topic belongs to. Always present when
+        #   listing a user's preferences; omitted by the single-topic read when the topic
+        #   has no resolvable section.
+        #
+        #   @return [String, nil]
+        optional :section_id, String
+
+        # @!attribute section_name
+        #   The display name of the section this topic belongs to. Always present when
+        #   listing a user's preferences; omitted by the single-topic read when the topic
+        #   has no resolvable section.
+        #
+        #   @return [String, nil]
+        optional :section_name, String
+
+        # @!method initialize(default_status:, status:, topic_id:, topic_name:, custom_routing: nil, has_custom_routing: nil, section_id: nil, section_name: nil)
         #   Some parameter documentations has been truncated, see
         #   {Courier::Models::Users::TopicPreference} for more details.
         #
@@ -63,6 +79,10 @@ module Courier
         #   @param custom_routing [Array<Symbol, Courier::Models::ChannelClassification>, nil] The channels the user has chosen to receive this topic on, present only when has
         #
         #   @param has_custom_routing [Boolean, nil] Whether the user has chosen specific delivery channels for this topic (listed in
+        #
+        #   @param section_id [String] The unique identifier of the section this topic belongs to. Always present when
+        #
+        #   @param section_name [String] The display name of the section this topic belongs to. Always present when listi
       end
     end
   end

--- a/rbi/courier/models/users/topic_preference.rbi
+++ b/rbi/courier/models/users/topic_preference.rbi
@@ -43,6 +43,24 @@ module Courier
         sig { returns(T.nilable(T::Boolean)) }
         attr_accessor :has_custom_routing
 
+        # The unique identifier of the section this topic belongs to. Always present when
+        # listing a user's preferences; omitted by the single-topic read when the topic
+        # has no resolvable section.
+        sig { returns(T.nilable(String)) }
+        attr_reader :section_id
+
+        sig { params(section_id: String).void }
+        attr_writer :section_id
+
+        # The display name of the section this topic belongs to. Always present when
+        # listing a user's preferences; omitted by the single-topic read when the topic
+        # has no resolvable section.
+        sig { returns(T.nilable(String)) }
+        attr_reader :section_name
+
+        sig { params(section_name: String).void }
+        attr_writer :section_name
+
         sig do
           params(
             default_status: Courier::PreferenceStatus::OrSymbol,
@@ -51,7 +69,9 @@ module Courier
             topic_name: String,
             custom_routing:
               T.nilable(T::Array[Courier::ChannelClassification::OrSymbol]),
-            has_custom_routing: T.nilable(T::Boolean)
+            has_custom_routing: T.nilable(T::Boolean),
+            section_id: String,
+            section_name: String
           ).returns(T.attached_class)
         end
         def self.new(
@@ -72,7 +92,15 @@ module Courier
           custom_routing: nil,
           # Whether the user has chosen specific delivery channels for this topic (listed in
           # custom_routing) rather than the topic's default routing.
-          has_custom_routing: nil
+          has_custom_routing: nil,
+          # The unique identifier of the section this topic belongs to. Always present when
+          # listing a user's preferences; omitted by the single-topic read when the topic
+          # has no resolvable section.
+          section_id: nil,
+          # The display name of the section this topic belongs to. Always present when
+          # listing a user's preferences; omitted by the single-topic read when the topic
+          # has no resolvable section.
+          section_name: nil
         )
         end
 
@@ -87,7 +115,9 @@ module Courier
                 T.nilable(
                   T::Array[Courier::ChannelClassification::TaggedSymbol]
                 ),
-              has_custom_routing: T.nilable(T::Boolean)
+              has_custom_routing: T.nilable(T::Boolean),
+              section_id: String,
+              section_name: String
             }
           )
         end

--- a/sig/courier/models/users/topic_preference.rbs
+++ b/sig/courier/models/users/topic_preference.rbs
@@ -8,7 +8,9 @@ module Courier
           topic_id: String,
           topic_name: String,
           custom_routing: ::Array[Courier::Models::channel_classification]?,
-          has_custom_routing: bool?
+          has_custom_routing: bool?,
+          section_id: String,
+          section_name: String
         }
 
       class TopicPreference < Courier::Internal::Type::BaseModel
@@ -24,13 +26,23 @@ module Courier
 
         attr_accessor has_custom_routing: bool?
 
+        attr_reader section_id: String?
+
+        def section_id=: (String) -> String
+
+        attr_reader section_name: String?
+
+        def section_name=: (String) -> String
+
         def initialize: (
           default_status: Courier::Models::preference_status,
           status: Courier::Models::preference_status,
           topic_id: String,
           topic_name: String,
           ?custom_routing: ::Array[Courier::Models::channel_classification]?,
-          ?has_custom_routing: bool?
+          ?has_custom_routing: bool?,
+          ?section_id: String,
+          ?section_name: String
         ) -> void
 
         def to_hash: -> {
@@ -39,7 +51,9 @@ module Courier
           topic_id: String,
           topic_name: String,
           custom_routing: ::Array[Courier::Models::channel_classification]?,
-          has_custom_routing: bool?
+          has_custom_routing: bool?,
+          section_id: String,
+          section_name: String
         }
       end
     end


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 71 insertions(+), 7 deletions(-)

<details><summary>Files</summary>

```
 lib/courier/models/users/topic_preference.rb  | 22 +++++++++++++++++++++-
 rbi/courier/models/users/topic_preference.rbi | 36 +++++++++++++++++++++++++++++++++---
 sig/courier/models/users/topic_preference.rbs | 20 +++++++++++++++++---
 3 files changed, 71 insertions(+), 7 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
