### PR TITLE
feat(api): document channel on journey send nodes [C-20309]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    trycourier (6.2.0)
+    trycourier (6.3.0)
       cgi
       connection_pool
 

--- a/lib/courier/models/journey_send_node.rb
+++ b/lib/courier/models/journey_send_node.rb
@@ -18,6 +18,15 @@ module Courier
       #   @return [String, nil]
       optional :id, String
 
+      # @!attribute channel
+      #   The channel this node sends through. Optional — when omitted, the field is
+      #   absent from the node, including on `GET`; nodes created before this field
+      #   existed have it unset. Setting it makes the node's channel explicit to any
+      #   client reading the journey.
+      #
+      #   @return [Symbol, Courier::Models::JourneySendNode::Channel, nil]
+      optional :channel, enum: -> { Courier::JourneySendNode::Channel }
+
       # @!attribute conditions
       #   Condition spec for a journey node. Accepts a single condition atom, an AND/OR
       #   group, or an AND/OR nested group. Omit the `conditions` property entirely to
@@ -34,7 +43,7 @@ module Courier
       #   @return [Courier::Models::JourneyExperiment, nil]
       optional :experiment, -> { Courier::JourneyExperiment }
 
-      # @!method initialize(message:, type:, id: nil, conditions: nil, experiment: nil)
+      # @!method initialize(message:, type:, id: nil, channel: nil, conditions: nil, experiment: nil)
       #   Some parameter documentations has been truncated, see
       #   {Courier::Models::JourneySendNode} for more details.
       #
@@ -49,6 +58,8 @@ module Courier
       #   @param type [Symbol, Courier::Models::JourneySendNode::Type]
       #
       #   @param id [String]
+      #
+      #   @param channel [Symbol, Courier::Models::JourneySendNode::Channel] The channel this node sends through. Optional — when omitted, the field is absen
       #
       #   @param conditions [Array<String>, Courier::Models::JourneyConditionGroup, Courier::Models::JourneyConditionNestedGroup] Condition spec for a journey node. Accepts a single condition atom, an AND/OR gr
       #
@@ -207,6 +218,26 @@ module Courier
         extend Courier::Internal::Type::Enum
 
         SEND = :send
+
+        # @!method self.values
+        #   @return [Array<Symbol>]
+      end
+
+      # The channel this node sends through. Optional — when omitted, the field is
+      # absent from the node, including on `GET`; nodes created before this field
+      # existed have it unset. Setting it makes the node's channel explicit to any
+      # client reading the journey.
+      #
+      # @see Courier::Models::JourneySendNode#channel
+      module Channel
+        extend Courier::Internal::Type::Enum
+
+        EMAIL = :email
+        SMS = :sms
+        PUSH = :push
+        INBOX = :inbox
+        SLACK = :slack
+        MSTEAMS = :msteams
 
         # @!method self.values
         #   @return [Array<Symbol>]

--- a/rbi/courier/models/journey_send_node.rbi
+++ b/rbi/courier/models/journey_send_node.rbi
@@ -23,6 +23,16 @@ module Courier
       sig { params(id: String).void }
       attr_writer :id
 
+      # The channel this node sends through. Optional — when omitted, the field is
+      # absent from the node, including on `GET`; nodes created before this field
+      # existed have it unset. Setting it makes the node's channel explicit to any
+      # client reading the journey.
+      sig { returns(T.nilable(Courier::JourneySendNode::Channel::OrSymbol)) }
+      attr_reader :channel
+
+      sig { params(channel: Courier::JourneySendNode::Channel::OrSymbol).void }
+      attr_writer :channel
+
       # Condition spec for a journey node. Accepts a single condition atom, an AND/OR
       # group, or an AND/OR nested group. Omit the `conditions` property entirely to
       # express "no conditions".
@@ -70,6 +80,7 @@ module Courier
           message: Courier::JourneySendNode::Message::OrHash,
           type: Courier::JourneySendNode::Type::OrSymbol,
           id: String,
+          channel: Courier::JourneySendNode::Channel::OrSymbol,
           conditions:
             T.any(
               T::Array[String],
@@ -83,6 +94,11 @@ module Courier
         message:,
         type:,
         id: nil,
+        # The channel this node sends through. Optional — when omitted, the field is
+        # absent from the node, including on `GET`; nodes created before this field
+        # existed have it unset. Setting it makes the node's channel explicit to any
+        # client reading the journey.
+        channel: nil,
         # Condition spec for a journey node. Accepts a single condition atom, an AND/OR
         # group, or an AND/OR nested group. Omit the `conditions` property entirely to
         # express "no conditions".
@@ -100,6 +116,7 @@ module Courier
             message: Courier::JourneySendNode::Message,
             type: Courier::JourneySendNode::Type::OrSymbol,
             id: String,
+            channel: Courier::JourneySendNode::Channel::OrSymbol,
             conditions:
               T.any(
                 T::Array[String],
@@ -412,6 +429,34 @@ module Courier
         sig do
           override.returns(
             T::Array[Courier::JourneySendNode::Type::TaggedSymbol]
+          )
+        end
+        def self.values
+        end
+      end
+
+      # The channel this node sends through. Optional — when omitted, the field is
+      # absent from the node, including on `GET`; nodes created before this field
+      # existed have it unset. Setting it makes the node's channel explicit to any
+      # client reading the journey.
+      module Channel
+        extend Courier::Internal::Type::Enum
+
+        TaggedSymbol =
+          T.type_alias { T.all(Symbol, Courier::JourneySendNode::Channel) }
+        OrSymbol = T.type_alias { T.any(Symbol, String) }
+
+        EMAIL = T.let(:email, Courier::JourneySendNode::Channel::TaggedSymbol)
+        SMS = T.let(:sms, Courier::JourneySendNode::Channel::TaggedSymbol)
+        PUSH = T.let(:push, Courier::JourneySendNode::Channel::TaggedSymbol)
+        INBOX = T.let(:inbox, Courier::JourneySendNode::Channel::TaggedSymbol)
+        SLACK = T.let(:slack, Courier::JourneySendNode::Channel::TaggedSymbol)
+        MSTEAMS =
+          T.let(:msteams, Courier::JourneySendNode::Channel::TaggedSymbol)
+
+        sig do
+          override.returns(
+            T::Array[Courier::JourneySendNode::Channel::TaggedSymbol]
           )
         end
         def self.values

--- a/sig/courier/models/journey_send_node.rbs
+++ b/sig/courier/models/journey_send_node.rbs
@@ -5,6 +5,7 @@ module Courier
         message: Courier::JourneySendNode::Message,
         type: Courier::Models::JourneySendNode::type_,
         id: String,
+        channel: Courier::Models::JourneySendNode::channel,
         conditions: Courier::Models::journey_conditions_field,
         experiment: Courier::JourneyExperiment
       }
@@ -17,6 +18,12 @@ module Courier
       attr_reader id: String?
 
       def id=: (String) -> String
+
+      attr_reader channel: Courier::Models::JourneySendNode::channel?
+
+      def channel=: (
+        Courier::Models::JourneySendNode::channel
+      ) -> Courier::Models::JourneySendNode::channel
 
       attr_reader conditions: Courier::Models::journey_conditions_field?
 
@@ -34,6 +41,7 @@ module Courier
         message: Courier::JourneySendNode::Message,
         type: Courier::Models::JourneySendNode::type_,
         ?id: String,
+        ?channel: Courier::Models::JourneySendNode::channel,
         ?conditions: Courier::Models::journey_conditions_field,
         ?experiment: Courier::JourneyExperiment
       ) -> void
@@ -42,6 +50,7 @@ module Courier
         message: Courier::JourneySendNode::Message,
         type: Courier::Models::JourneySendNode::type_,
         id: String,
+        channel: Courier::Models::JourneySendNode::channel,
         conditions: Courier::Models::journey_conditions_field,
         experiment: Courier::JourneyExperiment
       }
@@ -182,6 +191,21 @@ module Courier
         SEND: :send
 
         def self?.values: -> ::Array[Courier::Models::JourneySendNode::type_]
+      end
+
+      type channel = :email | :sms | :push | :inbox | :slack | :msteams
+
+      module Channel
+        extend Courier::Internal::Type::Enum
+
+        EMAIL: :email
+        SMS: :sms
+        PUSH: :push
+        INBOX: :inbox
+        SLACK: :slack
+        MSTEAMS: :msteams
+
+        def self?.values: -> ::Array[Courier::Models::JourneySendNode::channel]
       end
     end
   end


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

4 files changed, 102 insertions(+), 2 deletions(-)

<details><summary>Files</summary>

```
 Gemfile.lock                             |  2 +-
 lib/courier/models/journey_send_node.rb  | 33 ++++++++++++++++++++++++++++++++-
 rbi/courier/models/journey_send_node.rbi | 45 +++++++++++++++++++++++++++++++++++++++++++++
 sig/courier/models/journey_send_node.rbs | 24 ++++++++++++++++++++++++
 4 files changed, 102 insertions(+), 2 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
