### PR TITLE
fix(api): correct two Elemental field names the REST API rejects

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    trycourier (6.3.0)
+    trycourier (6.4.1)
       cgi
       connection_pool
 

--- a/lib/courier/models/elemental_image_node.rb
+++ b/lib/courier/models/elemental_image_node.rb
@@ -19,7 +19,7 @@ module Courier
       #   Alternate text for the image.
       #
       #   @return [String, nil]
-      optional :alt_text, String, api_name: :altText, nil?: true
+      optional :alt_text, String, nil?: true
 
       # @!attribute border_color
       #   CSS border color applied to the image. For example, `#ccc`

--- a/lib/courier/models/elemental_quote_node.rb
+++ b/lib/courier/models/elemental_quote_node.rb
@@ -19,7 +19,7 @@ module Courier
       #   CSS border color property. For example, `#fff`
       #
       #   @return [String, nil]
-      optional :border_color, String, api_name: :borderColor, nil?: true
+      optional :border_color, String, nil?: true
 
       # @!attribute font_size
       #   CSS px font size for this quote block, e.g. `16px`. Overrides the size of the


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 3 insertions(+), 3 deletions(-)

<details><summary>Files</summary>

```
 Gemfile.lock                               | 2 +-
 lib/courier/models/elemental_image_node.rb | 2 +-
 lib/courier/models/elemental_quote_node.rb | 2 +-
 3 files changed, 3 insertions(+), 3 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
