### PR TITLE
fix(api): text content is not required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    trycourier (6.4.1)
+    trycourier (6.4.2)
       cgi
       connection_pool
 

--- a/lib/courier/models/elemental_text_node.rb
+++ b/lib/courier/models/elemental_text_node.rb
@@ -3,13 +3,6 @@
 module Courier
   module Models
     class ElementalTextNode < Courier::Models::ElementalBaseNode
-      # @!attribute content
-      #   The text content displayed in the notification. Either this field must be
-      #   specified, or the elements field
-      #
-      #   @return [String]
-      required :content, String
-
       # @!attribute align
       #   Text alignment.
       #
@@ -27,6 +20,13 @@ module Courier
       #
       #   @return [String, nil]
       optional :color, String, nil?: true
+
+      # @!attribute content
+      #   The text content displayed in the notification. Either this field must be
+      #   specified, or the elements field
+      #
+      #   @return [String, nil]
+      optional :content, String
 
       # @!attribute font_size
       #   CSS px font size for this text block, e.g. `16px`. Overrides the size of the
@@ -79,19 +79,19 @@ module Courier
       #   @return [String, nil]
       optional :underline, String, nil?: true
 
-      # @!method initialize(content:, align: nil, bold: nil, color: nil, font_size: nil, format_: nil, italic: nil, line_height: nil, locales: nil, strikethrough: nil, text_style: nil, underline: nil)
+      # @!method initialize(align: nil, bold: nil, color: nil, content: nil, font_size: nil, format_: nil, italic: nil, line_height: nil, locales: nil, strikethrough: nil, text_style: nil, underline: nil)
       #   Some parameter documentations has been truncated, see
       #   {Courier::Models::ElementalTextNode} for more details.
       #
       #   Represents a body of text to be rendered inside of the notification.
-      #
-      #   @param content [String] The text content displayed in the notification. Either this
       #
       #   @param align [Symbol, Courier::Models::ElementalTextNode::Align] Text alignment.
       #
       #   @param bold [String, nil] Apply bold to the text
       #
       #   @param color [String, nil] Specifies the color of text. Can be any valid css color value
+      #
+      #   @param content [String] The text content displayed in the notification. Either this
       #
       #   @param font_size [String, nil] CSS px font size for this text block, e.g. `16px`. Overrides the size of the `te
       #

--- a/rbi/courier/models/elemental_text_node.rbi
+++ b/rbi/courier/models/elemental_text_node.rbi
@@ -8,11 +8,6 @@ module Courier
           T.any(Courier::ElementalTextNode, Courier::Internal::AnyHash)
         end
 
-      # The text content displayed in the notification. Either this field must be
-      # specified, or the elements field
-      sig { returns(String) }
-      attr_accessor :content
-
       # Text alignment.
       sig { returns(T.nilable(Courier::ElementalTextNode::Align::OrSymbol)) }
       attr_reader :align
@@ -27,6 +22,14 @@ module Courier
       # Specifies the color of text. Can be any valid css color value
       sig { returns(T.nilable(String)) }
       attr_accessor :color
+
+      # The text content displayed in the notification. Either this field must be
+      # specified, or the elements field
+      sig { returns(T.nilable(String)) }
+      attr_reader :content
+
+      sig { params(content: String).void }
+      attr_writer :content
 
       # CSS px font size for this text block, e.g. `16px`. Overrides the size of the
       # `text_style` preset. Email only.
@@ -66,10 +69,10 @@ module Courier
       # Represents a body of text to be rendered inside of the notification.
       sig do
         params(
-          content: String,
           align: Courier::ElementalTextNode::Align::OrSymbol,
           bold: T.nilable(String),
           color: T.nilable(String),
+          content: String,
           font_size: T.nilable(String),
           format_: T.nilable(Courier::ElementalTextNode::Format::OrSymbol),
           italic: T.nilable(String),
@@ -81,15 +84,15 @@ module Courier
         ).returns(T.attached_class)
       end
       def self.new(
-        # The text content displayed in the notification. Either this field must be
-        # specified, or the elements field
-        content:,
         # Text alignment.
         align: nil,
         # Apply bold to the text
         bold: nil,
         # Specifies the color of text. Can be any valid css color value
         color: nil,
+        # The text content displayed in the notification. Either this field must be
+        # specified, or the elements field
+        content: nil,
         # CSS px font size for this text block, e.g. `16px`. Overrides the size of the
         # `text_style` preset. Email only.
         font_size: nil,
@@ -115,10 +118,10 @@ module Courier
       sig do
         override.returns(
           {
-            content: String,
             align: Courier::ElementalTextNode::Align::OrSymbol,
             bold: T.nilable(String),
             color: T.nilable(String),
+            content: String,
             font_size: T.nilable(String),
             format_: T.nilable(Courier::ElementalTextNode::Format::OrSymbol),
             italic: T.nilable(String),

--- a/sig/courier/models/elemental_text_node.rbs
+++ b/sig/courier/models/elemental_text_node.rbs
@@ -2,10 +2,10 @@ module Courier
   module Models
     type elemental_text_node =
       {
-        content: String,
         align: Courier::Models::ElementalTextNode::align,
         bold: String?,
         color: String?,
+        content: String,
         font_size: String?,
         format_: Courier::Models::ElementalTextNode::format_?,
         italic: String?,
@@ -17,10 +17,6 @@ module Courier
       }
 
     class ElementalTextNode < Courier::Models::ElementalBaseNode
-      def content: -> String
-
-      def content=: (String _) -> String
-
       def align: -> Courier::Models::ElementalTextNode::align?
 
       def align=: (
@@ -34,6 +30,10 @@ module Courier
       def color: -> String?
 
       def color=: (String? _) -> String?
+
+      def content: -> String?
+
+      def content=: (String _) -> String
 
       def font_size: -> String?
 
@@ -72,10 +72,10 @@ module Courier
       def underline=: (String? _) -> String?
 
       def initialize: (
-        content: String,
         ?align: Courier::Models::ElementalTextNode::align,
         ?bold: String?,
         ?color: String?,
+        ?content: String,
         ?font_size: String?,
         ?format_: Courier::Models::ElementalTextNode::format_?,
         ?italic: String?,
@@ -87,10 +87,10 @@ module Courier
       ) -> void
 
       def to_hash: -> {
-        content: String,
         align: Courier::Models::ElementalTextNode::align,
         bold: String?,
         color: String?,
+        content: String,
         font_size: String?,
         format_: Courier::Models::ElementalTextNode::format_?,
         italic: String?,


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

4 files changed, 31 insertions(+), 28 deletions(-)

<details><summary>Files</summary>

```
 Gemfile.lock                               |  2 +-
 lib/courier/models/elemental_text_node.rb  | 20 ++++++++++----------
 rbi/courier/models/elemental_text_node.rbi | 23 +++++++++++++----------
 sig/courier/models/elemental_text_node.rbs | 14 +++++++-------
 4 files changed, 31 insertions(+), 28 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
